### PR TITLE
Add the ability to provide an alternative API URL for all the api calls.

### DIFF
--- a/R/LDexpress.R
+++ b/R/LDexpress.R
@@ -50,9 +50,9 @@ LDexpress <- function(snps, pop = "CEU", tissue = "ALL",
                       r2d = "r2", r2d_threshold = 0.1,
                       p_threshold = 0.1, win_size = 500000,
                       genome_build = "grch37",
-                      token = NULL, file = FALSE, api_root="https://ldlink.nci.nih.gov") {
+                      token = NULL, file = FALSE, api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
-     LD_config <- list(ldexpress_url_base = paste0(api_root,"/LDlinkRest/ldexpress"),
+     LD_config <- list(ldexpress_url_base = paste0(api_root,"/ldexpress"),
                        avail_pop = c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                      "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                      "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDexpress.R
+++ b/R/LDexpress.R
@@ -25,6 +25,7 @@
 #' data sets.  Default is GRCh37 (hg19).
 #' @param token LDlink provided user token, default = NULL, register for token at \url{https://ldlink.nci.nih.gov/?tab=apiaccess}
 #' @param file Optional character string naming a path and file for saving results.  If file = FALSE, no file will be generated, default = FALSE.
+#' @param api_root Optional alternative root url for API.
 #'
 #' @return A data frame of all query variant RS numbers, respective QTL which are in LD with query variant,
 #' and associated gene expression.
@@ -49,9 +50,9 @@ LDexpress <- function(snps, pop = "CEU", tissue = "ALL",
                       r2d = "r2", r2d_threshold = 0.1,
                       p_threshold = 0.1, win_size = 500000,
                       genome_build = "grch37",
-                      token = NULL, file = FALSE) {
+                      token = NULL, file = FALSE, api_root="https://ldlink.nci.nih.gov") {
 
-     LD_config <- list(ldexpress_url_base = "https://ldlink.nci.nih.gov/LDlinkRest/ldexpress",
+     LD_config <- list(ldexpress_url_base = paste0(api_root,"/LDlinkRest/ldexpress"),
                        avail_pop = c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                      "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                      "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDhap.R
+++ b/R/LDhap.R
@@ -105,6 +105,7 @@ df_merge <- function(data_out, table_type, genome_build) {
 #' @param genome_build Choose between one of the three options...`grch37` for genome build GRCh37 (hg19),
 #' `grch38` for GRCh38 (hg38), or `grch38_high_coverage` for GRCh38 High Coverage (hg38) 1000 Genome Project
 #' data sets.  Default is GRCh37 (hg19).
+#' @param api_root Optional alternative root url for API.
 #'
 #' @return a data frame or list
 #' @importFrom httr GET content stop_for_status http_error
@@ -120,11 +121,10 @@ LDhap <- function(snps,
                   token=NULL,
                   file = FALSE,
                   table_type="haplotype",
-                  genome_build = "grch37"
-                  ) {
+                  genome_build = "grch37",
+                  api_root="https://ldlink.nci.nih.gov") {
 
-
-  LD_config <- list(ldhap.url="https://ldlink.nci.nih.gov/LDlinkRest/ldhap",
+   LD_config <- list(ldhap.url=paste0(api_root,"/LDlinkRest/ldhap"),
                     avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDhap.R
+++ b/R/LDhap.R
@@ -122,9 +122,9 @@ LDhap <- function(snps,
                   file = FALSE,
                   table_type="haplotype",
                   genome_build = "grch37",
-                  api_root="https://ldlink.nci.nih.gov") {
+                  api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
-   LD_config <- list(ldhap.url=paste0(api_root,"/LDlinkRest/ldhap"),
+   LD_config <- list(ldhap.url=paste0(api_root,"/ldhap"),
                     avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDmatrix.R
+++ b/R/LDmatrix.R
@@ -11,6 +11,8 @@
 #' @param genome_build Choose between one of the three options...`grch37` for genome build GRCh37 (hg19),
 #' `grch38` for GRCh38 (hg38), or `grch38_high_coverage` for GRCh38 High Coverage (hg38) 1000 Genome Project
 #' data sets.  Default is GRCh37 (hg19).
+#' @param api_root Optional alternative root url for API.
+
 #' @return a data frame
 #' @importFrom httr GET content http_error stop_for_status
 #' @importFrom utils capture.output read.delim write.table
@@ -27,9 +29,10 @@ LDmatrix <- function(snps,
                      r2d="r2",
                      token=NULL,
                      file = FALSE,
-                     genome_build = "grch37") {
+                     genome_build = "grch37",
+                     api_root="https://ldlink.nci.nih.gov") {
 
-  LD_config <- list(ldmatrix_url="https://ldlink.nci.nih.gov/LDlinkRest/ldmatrix",
+  LD_config <- list(ldmatrix_url=paste0(api_root,"/LDlinkRest/ldmatrix"),
                     avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDmatrix.R
+++ b/R/LDmatrix.R
@@ -30,9 +30,9 @@ LDmatrix <- function(snps,
                      token=NULL,
                      file = FALSE,
                      genome_build = "grch37",
-                     api_root="https://ldlink.nci.nih.gov") {
+                     api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
-  LD_config <- list(ldmatrix_url=paste0(api_root,"/LDlinkRest/ldmatrix"),
+  LD_config <- list(ldmatrix_url=paste0(api_root,"/ldmatrix"),
                     avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDpair.R
+++ b/R/LDpair.R
@@ -77,9 +77,9 @@ LDpair <- function(var1,
                    output = "table",
                    file = FALSE,
                    genome_build = "grch37",
-                   api_root="https://ldlink.nci.nih.gov") {
+                   api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
-LD_config <- list(ldpair_url=paste0(api_root,"/LDlinkRest/ldpair"),
+LD_config <- list(ldpair_url=paste0(api_root,"/ldpair"),
                   avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                               "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                               "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDpair.R
+++ b/R/LDpair.R
@@ -59,6 +59,7 @@ df_pair_tbl <- data.frame(var1 = z[[1]][1],
 #' @param genome_build Choose between one of the three options...`grch37` for genome build GRCh37 (hg19),
 #' `grch38` for GRCh38 (hg38), or `grch38_high_coverage` for GRCh38 High Coverage (hg38) 1000 Genome Project
 #' data sets.  Default is GRCh37 (hg19).
+#' @param api_root Optional alternative root url for API.
 #'
 #' @return text or data frame, depending on the output option
 #' @importFrom httr GET content stop_for_status http_error
@@ -75,9 +76,10 @@ LDpair <- function(var1,
                    token=NULL,
                    output = "table",
                    file = FALSE,
-                   genome_build = "grch37") {
+                   genome_build = "grch37",
+                   api_root="https://ldlink.nci.nih.gov") {
 
-LD_config <- list(ldpair_url="https://ldlink.nci.nih.gov/LDlinkRest/ldpair",
+LD_config <- list(ldpair_url=paste0(api_root,"/LDlinkRest/ldpair"),
                   avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                               "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                               "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDpop.R
+++ b/R/LDpop.R
@@ -32,9 +32,9 @@ LDpop <- function(var1,
                   token=NULL,
                   file = FALSE,
                   genome_build = "grch37",
-                  api_root="https://ldlink.nci.nih.gov") {
+                  api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
-  LD_config <- list(ldpop_url=paste0(api_root,"/LDlinkRest/ldpop"),
+  LD_config <- list(ldpop_url=paste0(api_root,"/ldpop"),
                   avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDpop.R
+++ b/R/LDpop.R
@@ -12,6 +12,7 @@
 #' @param genome_build Choose between one of the three options...`grch37` for genome build GRCh37 (hg19),
 #' `grch38` for GRCh38 (hg38), or `grch38_high_coverage` for GRCh38 High Coverage (hg38) 1000 Genome Project
 #' data sets.  Default is GRCh37 (hg19).
+#' @param api_root Optional alternative root url for API.
 #'
 #' @return a data frame
 #' @importFrom httr GET content stop_for_status http_error
@@ -30,9 +31,10 @@ LDpop <- function(var1,
                   r2d="r2",
                   token=NULL,
                   file = FALSE,
-                  genome_build = "grch37") {
+                  genome_build = "grch37",
+                  api_root="https://ldlink.nci.nih.gov") {
 
-LD_config <- list(ldpop_url="https://ldlink.nci.nih.gov/LDlinkRest/ldpop",
+  LD_config <- list(ldpop_url=paste0(api_root,"/LDlinkRest/ldpop"),
                   avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDproxy.R
+++ b/R/LDproxy.R
@@ -11,6 +11,7 @@
 #' @param genome_build Choose between one of the three options...`grch37` for genome build GRCh37 (hg19),
 #' `grch38` for GRCh38 (hg38), or `grch38_high_coverage` for GRCh38 High Coverage (hg38) 1000 Genome Project
 #' data sets.  Default is GRCh37 (hg19).
+#' @param api_root Optional alternative root url for API.
 #'
 #' @return a data frame
 #' @importFrom httr GET content stop_for_status http_error
@@ -25,10 +26,10 @@ LDproxy <- function(snp,
                     r2d="r2",
                     token=NULL,
                     file = FALSE,
-                    genome_build = "grch37") {
+                    genome_build = "grch37",
+                    api_root="https://ldlink.nci.nih.gov") {
 
-
-LD_config <- list(ldproxy.url="https://ldlink.nci.nih.gov/LDlinkRest/ldproxy",
+  LD_config <- list(ldproxy.url=paste0(api_root,"/LDlinkRest/ldproxy"),
                     avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDproxy.R
+++ b/R/LDproxy.R
@@ -27,9 +27,9 @@ LDproxy <- function(snp,
                     token=NULL,
                     file = FALSE,
                     genome_build = "grch37",
-                    api_root="https://ldlink.nci.nih.gov") {
+                    api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
-  LD_config <- list(ldproxy.url=paste0(api_root,"/LDlinkRest/ldproxy"),
+  LD_config <- list(ldproxy.url=paste0(api_root,"/ldproxy"),
                     avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDproxy_batch.R
+++ b/R/LDproxy_batch.R
@@ -12,6 +12,7 @@
 #' @param genome_build Choose between one of the three options...`grch37` for genome build GRCh37 (hg19),
 #' `grch38` for GRCh38 (hg38), or `grch38_high_coverage` for GRCh38 High Coverage (hg38) 1000 Genome Project
 #' data sets.  Default is GRCh37 (hg19).
+#' @param api_root Optional alternative root url for API.
 #'
 #' @return text file(s) are saved to the current working directory.
 #' @importFrom utils write.table
@@ -26,7 +27,8 @@ LDproxy_batch <- function(snp,
                           r2d="r2",
                           token=NULL,
                           append = FALSE,
-                          genome_build = "grch37") {
+                          genome_build = "grch37",
+                          api_root="https://ldlink.nci.nih.gov") {
 
   snp <- as.data.frame(snp)
 
@@ -60,7 +62,8 @@ LDproxy_batch <- function(snp,
                           pop = pop,
                           r2d = r2d,
                           token = token,
-                          genome_build = genome_build)
+                          genome_build = genome_build,
+                          api_root)
       if(!(grepl("error", df_proxy[1,1])))
       {
         # add new column, query_snp

--- a/R/LDproxy_batch.R
+++ b/R/LDproxy_batch.R
@@ -28,7 +28,7 @@ LDproxy_batch <- function(snp,
                           token=NULL,
                           append = FALSE,
                           genome_build = "grch37",
-                          api_root="https://ldlink.nci.nih.gov") {
+                          api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
   snp <- as.data.frame(snp)
 

--- a/R/LDtrait.R
+++ b/R/LDtrait.R
@@ -20,6 +20,7 @@
 #' @param genome_build Choose between one of the three options...`grch37` for genome build GRCh37 (hg19),
 #' `grch38` for GRCh38 (hg38), or `grch38_high_coverage` for GRCh38 High Coverage (hg38) 1000 Genome Project
 #' data sets.  Default is GRCh37 (hg19).
+#' @param api_root Optional alternative root url for API.
 #'
 #' @return A data frame of all query variant RS numbers with a list of queried variants
 #' in LD with a variant reported in the GWAS Catalog (\url{https://www.ebi.ac.uk/gwas/docs/file-downloads}.
@@ -44,9 +45,10 @@ LDtrait <- function(snps,
                     win_size = 500000,
                     token = NULL,
                     file = FALSE,
-                    genome_build = "grch37") {
+                    genome_build = "grch37",
+                    api_root="https://ldlink.nci.nih.gov") {
 
-LD_config <- list(ldtrait_url_base = "https://ldlink.nci.nih.gov/LDlinkRest/ldtrait",
+LD_config <- list(ldtrait_url_base = paste0(api_root,"/LDlinkRest/ldtrait"),
                   avail_pop = c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/LDtrait.R
+++ b/R/LDtrait.R
@@ -46,9 +46,9 @@ LDtrait <- function(snps,
                     token = NULL,
                     file = FALSE,
                     genome_build = "grch37",
-                    api_root="https://ldlink.nci.nih.gov") {
+                    api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
-LD_config <- list(ldtrait_url_base = paste0(api_root,"/LDlinkRest/ldtrait"),
+LD_config <- list(ldtrait_url_base = paste0(api_root,"/ldtrait"),
                   avail_pop = c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                                 "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                                 "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/SNPchip.R
+++ b/R/SNPchip.R
@@ -130,6 +130,7 @@ format_tbl <- function(out_raw) {
 #' @param genome_build Choose between one of the three options...`grch37` for genome build GRCh37 (hg19),
 #' `grch38` for GRCh38 (hg38), or `grch38_high_coverage` for GRCh38 High Coverage (hg38) 1000 Genome Project
 #' data sets.  Default is GRCh37 (hg19).
+#' @param api_root Optional alternative root url for API.
 #'
 #' @return a data frame
 #' @importFrom httr POST content stop_for_status http_error
@@ -150,9 +151,10 @@ SNPchip <- function(snps,
                     chip="ALL",
                     token=NULL,
                     file = FALSE,
-                    genome_build = "grch37") {
+                    genome_build = "grch37",
+                    api_root="https://ldlink.nci.nih.gov") {
 
-LD_config <- list(snpchip_url_base="https://ldlink.nci.nih.gov/LDlinkRest/snpchip",
+LD_config <- list(snpchip_url_base=paste0(api_root,"/LDlinkRest/snpchip"),
                   avail_chip=c("I_100","I_1M","I_1M-D","I_240S","I_300","I_300-D","I_550v1",
                                "I_550v3","I_610-Q","I_650Y","I_660W-Q","I_CNV-12","I_CNV370-D",
                                "I_CNV370-Q","I_CVD","I_CardioMetab","I_Core-12","I_CoreE-12v1",

--- a/R/SNPchip.R
+++ b/R/SNPchip.R
@@ -152,9 +152,9 @@ SNPchip <- function(snps,
                     token=NULL,
                     file = FALSE,
                     genome_build = "grch37",
-                    api_root="https://ldlink.nci.nih.gov") {
+                    api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
-LD_config <- list(snpchip_url_base=paste0(api_root,"/LDlinkRest/snpchip"),
+LD_config <- list(snpchip_url_base=paste0(api_root,"/snpchip"),
                   avail_chip=c("I_100","I_1M","I_1M-D","I_240S","I_300","I_300-D","I_550v1",
                                "I_550v3","I_610-Q","I_650Y","I_660W-Q","I_CNV-12","I_CNV370-D",
                                "I_CNV370-Q","I_CVD","I_CardioMetab","I_Core-12","I_CoreE-12v1",

--- a/R/SNPclip.R
+++ b/R/SNPclip.R
@@ -30,9 +30,9 @@ SNPclip <- function(snps,
                     token=NULL,
                     file = FALSE,
                     genome_build = "grch37",
-                    api_root="https://ldlink.nci.nih.gov") {
+                    api_root="https://ldlink.nci.nih.gov/LDlinkRest") {
 
-LD_config <- list(snpclip_url=paste0(api_root,"/LDlinkRest/snpclip"),
+LD_config <- list(snpclip_url=paste0(api_root,"/snpclip"),
                   avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                               "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                               "CDX","KHV","CEU","TSI","FIN","GBR","IBS",

--- a/R/SNPclip.R
+++ b/R/SNPclip.R
@@ -11,6 +11,7 @@
 #' @param genome_build Choose between one of the three options...`grch37` for genome build GRCh37 (hg19),
 #' `grch38` for GRCh38 (hg38), or `grch38_high_coverage` for GRCh38 High Coverage (hg38) 1000 Genome Project
 #' data sets.  Default is GRCh37 (hg19).
+#' @param api_root Optional alternative root url for API.
 #'
 #' @return a data frame
 #' @importFrom httr POST content stop_for_status http_error
@@ -28,9 +29,10 @@ SNPclip <- function(snps,
                     maf_threshold="0.01",
                     token=NULL,
                     file = FALSE,
-                    genome_build = "grch37") {
+                    genome_build = "grch37",
+                    api_root="https://ldlink.nci.nih.gov") {
 
-LD_config <- list(snpclip_url="https://ldlink.nci.nih.gov/LDlinkRest/snpclip",
+LD_config <- list(snpclip_url=paste0(api_root,"/LDlinkRest/snpclip"),
                   avail_pop=c("YRI","LWK","GWD","MSL","ESN","ASW","ACB",
                               "MXL","PUR","CLM","PEL","CHB","JPT","CHS",
                               "CDX","KHV","CEU","TSI","FIN","GBR","IBS",


### PR DESCRIPTION
For the purpose of enabling a situation where the API is provided by an alternative base URL, this PR enables the user to easily switch to the other server.

it would be better to implement this with a state variable, but I thought that it might seem to intrusive to add that to the package.